### PR TITLE
test(logger): update test description to reflect removal of level pro…

### DIFF
--- a/lib/logger/__tests__/logger.test.ts
+++ b/lib/logger/__tests__/logger.test.ts
@@ -349,7 +349,7 @@ describe('logger', () => {
       expect(typeof noopLogger.error).toBe('function');
     });
 
-    it('both logger types have level property', () => {
+    it('both logger types have same method signatures', () => {
       const consoleLogger = createConsoleLogger('warn');
       const noopLogger = createNoopLogger();
 


### PR DESCRIPTION
…perty

The test description 'both logger types have level property' was misleading after removing the level property. Updated to 'both logger types have same method signatures' to accurately reflect what the test validates.

Addresses review feedback from gemini-code-assist[bot].