### PR TITLE
fix(fetcher): distinguish timeout from AbortError

### DIFF
--- a/lib/fetcher/__tests__/client/fetch-with-timeout/fetch-with-timeout.test.ts
+++ b/lib/fetcher/__tests__/client/fetch-with-timeout/fetch-with-timeout.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createFetchWithTimeout } from '../../../client/fetch-with-timeout.js';
+import { PromidasTimeoutError } from '../../../utils/errors/timeout-error.js';
+
+describe('createFetchWithTimeout', () => {
+  it('throws PromidasTimeoutError when the timeout triggers', async () => {
+    vi.useFakeTimers();
+
+    try {
+      const baseFetch = vi.fn((_, init) => {
+        return new Promise<Response>((_, reject) => {
+          init?.signal?.addEventListener(
+            'abort',
+            () => {
+              reject(new DOMException('Aborted', 'AbortError'));
+            },
+            { once: true },
+          );
+        });
+      });
+      const fetchWithTimeout = createFetchWithTimeout({
+        timeoutMs: 10,
+        baseFetch,
+      });
+
+      const promise = fetchWithTimeout('https://example.test', {});
+      const assertion =
+        expect(promise).rejects.toBeInstanceOf(PromidasTimeoutError);
+
+      await vi.advanceTimersByTimeAsync(20);
+      await Promise.resolve();
+
+      await assertion;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('preserves AbortError when caller aborts', async () => {
+    const abortError = new DOMException('Aborted', 'AbortError');
+
+    const baseFetch = vi.fn(async () => {
+      throw abortError;
+    });
+
+    const controller = new AbortController();
+    controller.abort();
+
+    const fetchWithTimeout = createFetchWithTimeout({
+      timeoutMs: 10,
+      baseFetch,
+    });
+
+    await expect(
+      fetchWithTimeout('https://example.test', { signal: controller.signal }),
+    ).rejects.toBe(abortError);
+  });
+});

--- a/lib/fetcher/__tests__/client/protopedia-api-custom-client/constructor/initialization.test.ts
+++ b/lib/fetcher/__tests__/client/protopedia-api-custom-client/constructor/initialization.test.ts
@@ -104,7 +104,6 @@ describe('ProtopediaApiCustomClient - Constructor - Initialization', () => {
 
     expect(createProtoPediaClientMock).toHaveBeenCalledWith({
       fetch: expect.any(Function),
-      timeoutMs,
       userAgent: expect.stringMatching(
         /^ProtopediaApiCustomClient\/\d+\.\d+\.\d+ \(promidas\)$/,
       ),

--- a/lib/fetcher/__tests__/utils/errors/handler/abort-error.test.ts
+++ b/lib/fetcher/__tests__/utils/errors/handler/abort-error.test.ts
@@ -23,8 +23,12 @@ describe('handleApiError - AbortError handling', () => {
 
     expect(result).toEqual({
       ok: false,
-      error: 'Upstream request timed out',
-      details: {},
+      error: 'Upstream request aborted',
+      details: {
+        res: {
+          code: 'ABORTED',
+        },
+      },
     });
   });
 

--- a/lib/fetcher/__tests__/utils/errors/handler/timeout-error.test.ts
+++ b/lib/fetcher/__tests__/utils/errors/handler/timeout-error.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+
+import { handleApiError } from '../../../../utils/errors/handler.js';
+import { PromidasTimeoutError } from '../../../../utils/errors/timeout-error.js';
+
+describe('handleApiError - PromidasTimeoutError handling', () => {
+  it('maps PromidasTimeoutError to TIMEOUT with code', () => {
+    const timeoutError = new PromidasTimeoutError(5000);
+    const result = handleApiError(timeoutError);
+
+    expect(result).toEqual({
+      ok: false,
+      error: 'Upstream request timed out',
+      details: {
+        res: {
+          code: 'TIMEOUT',
+        },
+      },
+    });
+  });
+});

--- a/lib/fetcher/client/fetch-with-timeout.ts
+++ b/lib/fetcher/client/fetch-with-timeout.ts
@@ -1,0 +1,61 @@
+import { PromidasTimeoutError } from '../utils/errors/timeout-error.js';
+
+export interface FetchWithTimeoutConfig {
+  timeoutMs: number;
+  baseFetch?: typeof fetch;
+}
+
+function isAbortError(error: unknown): error is DOMException {
+  return error instanceof DOMException && error.name === 'AbortError';
+}
+
+export function createFetchWithTimeout(
+  config: FetchWithTimeoutConfig,
+): typeof fetch {
+  const { timeoutMs, baseFetch } = config;
+
+  return async (url, init) => {
+    const fetchFn = baseFetch ?? globalThis.fetch;
+
+    const controller = new AbortController();
+    const timeoutError = new PromidasTimeoutError(timeoutMs);
+
+    const abortFromCaller = () => {
+      // Preserve caller-provided abort reason when available
+      controller.abort(init?.signal?.reason);
+    };
+
+    if (init?.signal?.aborted) {
+      abortFromCaller();
+    } else if (init?.signal) {
+      init.signal.addEventListener('abort', abortFromCaller, { once: true });
+    }
+
+    const timeoutId = setTimeout(() => {
+      controller.abort(timeoutError);
+    }, timeoutMs);
+
+    try {
+      return await fetchFn(url, {
+        ...init,
+        signal: controller.signal,
+      });
+    } catch (error) {
+      // Some runtimes may reject with AbortError instead of the abort reason.
+      if (error === timeoutError) {
+        throw error;
+      }
+
+      if (isAbortError(error) && controller.signal.reason === timeoutError) {
+        throw timeoutError;
+      }
+
+      throw error;
+    } finally {
+      clearTimeout(timeoutId);
+      if (init?.signal) {
+        init.signal.removeEventListener('abort', abortFromCaller);
+      }
+    }
+  };
+}

--- a/lib/fetcher/utils/errors/timeout-error.ts
+++ b/lib/fetcher/utils/errors/timeout-error.ts
@@ -1,0 +1,9 @@
+export class PromidasTimeoutError extends Error {
+  readonly timeoutMs: number;
+
+  constructor(timeoutMs: number, message?: string) {
+    super(message ?? `Upstream request timed out after ${timeoutMs}ms`);
+    this.name = 'PromidasTimeoutError';
+    this.timeoutMs = timeoutMs;
+  }
+}


### PR DESCRIPTION
Fixes #60.

## Summary
- Introduce `PromidasTimeoutError` and a `createFetchWithTimeout` wrapper.
- Classify explicit timeouts as `TIMEOUT` and generic `AbortError` as `ABORTED`.

## Tests
- `npm test`