### PR TITLE
chore(deps): remove redundant @types/eslint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
       },
       "devDependencies": {
         "@faker-js/faker": "^10.5.0",
-        "@types/eslint": "^9.6.1",
         "@types/node": "^24.13.2",
         "@typescript-eslint/eslint-plugin": "^8.62.1",
         "@typescript-eslint/parser": "^8.62.1",
@@ -1878,17 +1877,6 @@
       "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/eslint": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
-      "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "*",
-        "@types/json-schema": "*"
-      }
     },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@faker-js/faker": "^10.5.0",
-    "@types/eslint": "^9.6.1",
     "@types/node": "^24.13.2",
     "@typescript-eslint/eslint-plugin": "^8.62.1",
     "@typescript-eslint/parser": "^8.62.1",


### PR DESCRIPTION
## Summary

Follow-up to #113. Removes the redundant `@types/eslint` devDependency, as flagged by the gemini-code-assist review ([discussion](https://github.com/F88/promidas/pull/113#discussion_r3527702289)).

## Why

Since ESLint v9.10 and v10, type definitions are bundled directly into the `eslint` package, making the standalone `@types/eslint` package redundant. Keeping it around risks type resolution conflicts.

- The only eslint type usage — `eslint.config.mjs` (`import('eslint').Linter.Config`) — resolves from the bundled types in `node_modules/eslint/lib/types`.
- `@types/eslint` was a direct devDependency only; no package depends on it transitively.

## Verification

All checks pass locally:

- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm test` — 1346 tests
- `npm run format:check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
