### PR TITLE
feat(fetcher): add HTTP status to progress events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+#### `lib/fetcher`
+
+- **Progress events**: `FetchProgressEvent` variants emitted after response
+  headers arrive (`response-received`, `download-progress`, `complete`,
+  `error`) now carry a required readonly `status` field with the HTTP status
+  code. Real-time consumers can now distinguish a completed transfer of an
+  error body (e.g. a 97-byte 401 JSON payload) from a successful fetch,
+  instead of reporting "download complete" for error responses (#126).
+    - `complete` remains a fact report ("the body transfer finished") and
+      fires for 4xx/5xx as well, mirroring WHATWG `fetch` semantics; check
+      `status` before presenting it as a success.
+    - Not breaking for normal callback consumers: receiving events is
+      unaffected. Only code that constructs `FetchProgressEvent` objects
+      itself (e.g. mocks in tests) must now supply `status`.
+
 ## [3.0.1] - 2026-07-06
 
 ### Fixed

--- a/lib/fetcher/__tests__/client/fetch-with-progress/fetch-with-progress.test.ts
+++ b/lib/fetcher/__tests__/client/fetch-with-progress/fetch-with-progress.test.ts
@@ -130,6 +130,7 @@ describe('createFetchWithProgress', () => {
       expect(responseReceivedEvent).toBeDefined();
       expect(responseReceivedEvent![0]).toMatchObject({
         type: 'response-received',
+        status: 200,
         prepareTimeMs: expect.any(Number),
         estimatedTotal: expect.any(Number),
         limit: 100,
@@ -166,6 +167,7 @@ describe('createFetchWithProgress', () => {
       expect(completeEvent).toBeDefined();
       expect(completeEvent![0]).toMatchObject({
         type: 'complete',
+        status: 200,
         received: 4,
         estimatedTotal: expect.any(Number),
         downloadTimeMs: expect.any(Number),
@@ -240,11 +242,72 @@ describe('createFetchWithProgress', () => {
       expect(completeEvent).toBeDefined();
       expect(completeEvent![0]).toMatchObject({
         type: 'complete',
+        status: 204,
         received: 0,
         estimatedTotal: expect.any(Number),
         downloadTimeMs: 0,
         totalTimeMs: expect.any(Number),
       });
+    });
+
+    it('carries HTTP status on events for error responses (4xx)', async () => {
+      const logger = createConsoleLogger();
+      const events: FetchProgressEvent[] = [];
+      const onProgressEvent = vi.fn((event) => {
+        events.push(event);
+      });
+
+      const customFetch = createFetchWithProgress({
+        logger,
+        enableProgressLog: false,
+        onProgressEvent,
+      });
+
+      // Simulate a 401 error JSON body without Content-Length,
+      // as returned by the ProtoPedia API for an invalid token
+      const errorBody = JSON.stringify({ code: 'CLIENT_UNAUTHORIZED' });
+      const mockResponse = new Response(errorBody, {
+        status: 401,
+        headers: { 'Content-Type': 'application/json' },
+      });
+
+      global.fetch = vi.fn().mockResolvedValue(mockResponse);
+
+      const response = await customFetch(
+        'https://api.example.com/data?limit=10000',
+      );
+      await response.text();
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      // The body transfer completes, so 'complete' (not 'error') fires,
+      // but consumers can now detect the failure via status
+      const responseReceivedEvent = events.find(
+        (e) => e.type === 'response-received',
+      );
+      expect(responseReceivedEvent).toBeDefined();
+      expect(responseReceivedEvent).toMatchObject({
+        type: 'response-received',
+        status: 401,
+      });
+
+      const downloadProgressEvent = events.find(
+        (e) => e.type === 'download-progress',
+      );
+      expect(downloadProgressEvent).toBeDefined();
+      expect(downloadProgressEvent).toMatchObject({
+        type: 'download-progress',
+        status: 401,
+      });
+
+      const completeEvent = events.find((e) => e.type === 'complete');
+      expect(completeEvent).toBeDefined();
+      expect(completeEvent).toMatchObject({
+        type: 'complete',
+        status: 401,
+        received: errorBody.length,
+      });
+
+      expect(events.some((e) => e.type === 'error')).toBe(false);
     });
   });
 
@@ -707,6 +770,7 @@ describe('createFetchWithProgress', () => {
       expect(errorEvents).toHaveLength(1);
       expect(errorEvents[0]).toMatchObject({
         type: 'error',
+        status: 200,
         error: 'Stream read error',
         received: 3,
         estimatedTotal: 100,
@@ -762,6 +826,7 @@ describe('createFetchWithProgress', () => {
       expect(errorEvents).toHaveLength(1);
       expect(errorEvents[0]).toMatchObject({
         type: 'error',
+        status: 200,
         error: 'Non-Error value thrown',
         received: 3,
         estimatedTotal: 100,
@@ -827,6 +892,7 @@ describe('createFetchWithProgress', () => {
       expect(errorEvents).toHaveLength(1);
       expect(errorEvents[0]).toMatchObject({
         type: 'error',
+        status: 200,
         error: 'Stream read error',
         received: 3,
         estimatedTotal: 100,

--- a/lib/fetcher/client/fetch-with-progress.ts
+++ b/lib/fetcher/client/fetch-with-progress.ts
@@ -197,7 +197,9 @@ function estimateTotalSize(url: string): {
  *         break;
  *       case 'complete':
  *         progressBar?.complete();
- *         console.log(`Downloaded ${event.received} bytes in ${event.totalTimeMs}ms`);
+ *         if (event.status >= 200 && event.status < 300) {
+ *           console.log(`Downloaded ${event.received} bytes in ${event.totalTimeMs}ms`);
+ *         }
  *         break;
  *     }
  *   },
@@ -261,6 +263,7 @@ export function createFetchWithProgress(
     }
     onProgressEvent?.({
       type: 'response-received',
+      status: response.status,
       prepareTimeMs,
       estimatedTotal: total,
       limit: estimatedItemCount,
@@ -285,6 +288,7 @@ export function createFetchWithProgress(
 
       onProgressEvent?.({
         type: 'complete',
+        status: response.status,
         received: 0,
         estimatedTotal: total,
         downloadTimeMs: 0,
@@ -326,6 +330,7 @@ export function createFetchWithProgress(
               // Fire complete event
               onProgressEvent?.({
                 type: 'complete',
+                status: response.status,
                 received,
                 estimatedTotal: total,
                 downloadTimeMs: bodyElapsedMs,
@@ -363,6 +368,7 @@ export function createFetchWithProgress(
               // Fire download-progress event
               onProgressEvent?.({
                 type: 'download-progress',
+                status: response.status,
                 received,
                 total,
                 percentage,
@@ -395,6 +401,7 @@ export function createFetchWithProgress(
           // Fire error event
           onProgressEvent?.({
             type: 'error',
+            status: response.status,
             error: errorMessage,
             received,
             estimatedTotal: total,

--- a/lib/fetcher/docs/DESIGN_PROGRESS.md
+++ b/lib/fetcher/docs/DESIGN_PROGRESS.md
@@ -94,6 +94,7 @@ onProgressEvent?.({ type: 'request-start' });
 // 2. response-received: Fired when headers are received
 onProgressEvent?.({
     type: 'response-received',
+    status: number, // HTTP status code (also fires for 4xx/5xx)
     prepareTimeMs: number, // Time from request start to headers
     estimatedTotal: number, // Estimated download size
     limit: number, // From URL parameter
@@ -102,23 +103,27 @@ onProgressEvent?.({
 // 3. download-progress: Fired periodically during body download (throttled to 500ms)
 onProgressEvent?.({
     type: 'download-progress',
+    status: number, // HTTP status code
     received: number,
     total: number,
     percentage: number,
 });
 
-// 4. complete: Fired when download finishes successfully
+// 4. complete: Fired when the body transfer finishes
+//    (fact report - fires for 4xx/5xx error bodies too; check status)
 onProgressEvent?.({
     type: 'complete',
+    status: number, // HTTP status code
     received: number,
     estimatedTotal: number,
     downloadTimeMs: number, // Body download time
     totalTimeMs: number, // Request start to complete
 });
 
-// 5. error: Fired when stream reading fails
+// 5. error: Fired when stream reading fails (regardless of HTTP status)
 onProgressEvent?.({
     type: 'error',
+    status: number, // HTTP status code of the response being read
     error: string, // Error message
     received: number, // Bytes received before error
     estimatedTotal: number,

--- a/lib/fetcher/docs/USAGE.md
+++ b/lib/fetcher/docs/USAGE.md
@@ -227,9 +227,15 @@ const client = new ProtopediaApiCustomClient({
                 );
                 break;
             case 'complete':
-                console.log(
-                    `\nComplete: ${event.received} bytes in ${event.downloadTimeMs}ms (total: ${event.totalTimeMs}ms)`,
-                );
+                if (event.status >= 200 && event.status < 300) {
+                    console.log(
+                        `\nComplete: ${event.received} bytes in ${event.downloadTimeMs}ms (total: ${event.totalTimeMs}ms)`,
+                    );
+                } else {
+                    // Error body transfer finished (e.g. 401 JSON payload);
+                    // let the caller's error handling report the failure
+                    console.log(`\nTransfer finished with HTTP ${event.status}`);
+                }
                 break;
             case 'error':
                 console.error(
@@ -255,24 +261,30 @@ type FetchProgressEvent =
     | FetchProgressRequestStartEvent // Fired when fetch() is called
     | FetchProgressResponseReceivedEvent // Fired when headers are received
     | FetchProgressDownloadProgressEvent // Fired during body download (throttled to 500ms)
-    | FetchProgressCompleteEvent // Fired when download completes successfully
+    | FetchProgressCompleteEvent // Fired when the body transfer finishes (check status - fires for 4xx/5xx too)
     | FetchProgressErrorEvent; // Fired when stream reading fails
 ```
 
 **Event Properties**:
 
-| Event Type          | Properties                                                           |
-| ------------------- | -------------------------------------------------------------------- |
-| `request-start`     | `type: 'request-start'`                                              |
-| `response-received` | `type, prepareTimeMs, estimatedTotal, limit`                         |
-| `download-progress` | `type, received, total, percentage`                                  |
-| `complete`          | `type, received, estimatedTotal, downloadTimeMs, totalTimeMs`        |
-| `error`             | `type, error, received, estimatedTotal, downloadTimeMs, totalTimeMs` |
+| Event Type          | Properties                                                                   |
+| ------------------- | ---------------------------------------------------------------------------- |
+| `request-start`     | `type: 'request-start'`                                                      |
+| `response-received` | `type, status, prepareTimeMs, estimatedTotal, limit`                         |
+| `download-progress` | `type, status, received, total, percentage`                                  |
+| `complete`          | `type, status, received, estimatedTotal, downloadTimeMs, totalTimeMs`        |
+| `error`             | `type, status, error, received, estimatedTotal, downloadTimeMs, totalTimeMs` |
+
+All events fired after response headers arrive carry `status` (the HTTP
+status code). `complete` means the body transfer finished, not that the
+request succeeded - an error body (e.g. a 401 JSON payload) also ends
+with `complete`, so check `status` before presenting it as a success.
 
 **Event Lifecycle**:
 
 - **Success flow**: `request-start` → `response-received` → `download-progress` (multiple) → `complete`
-- **Error flow**: `request-start` → `response-received` → `download-progress` (optional) → `error` (stream reading fails)
+- **HTTP error flow (4xx/5xx)**: same as the success flow - the error body is still a body, so its transfer ends with `complete` (with `status` 4xx/5xx), not `error`
+- **Error flow**: `request-start` → `response-received` → `download-progress` (optional) → `error` (stream reading fails, regardless of HTTP status)
 
 ### Controlling stderr Output
 

--- a/lib/fetcher/docs/USAGE.md
+++ b/lib/fetcher/docs/USAGE.md
@@ -234,7 +234,9 @@ const client = new ProtopediaApiCustomClient({
                 } else {
                     // Error body transfer finished (e.g. 401 JSON payload);
                     // let the caller's error handling report the failure
-                    console.log(`\nTransfer finished with HTTP ${event.status}`);
+                    console.log(
+                        `\nTransfer finished with HTTP ${event.status}`,
+                    );
                 }
                 break;
             case 'error':

--- a/lib/fetcher/types/progress-event.types.ts
+++ b/lib/fetcher/types/progress-event.types.ts
@@ -42,6 +42,14 @@ export type FetchProgressRequestStartEvent = {
 export type FetchProgressResponseReceivedEvent = {
   readonly type: 'response-received';
   /**
+   * HTTP status code of the response (e.g., 200, 401, 404).
+   *
+   * This event fires for any response whose headers arrived, including
+   * 4xx/5xx errors. Consumers should check this value before presenting
+   * the download as a successful fetch.
+   */
+  readonly status: number;
+  /**
    * Time spent from request start to header reception (milliseconds).
    */
   readonly prepareTimeMs: number;
@@ -74,6 +82,13 @@ export type FetchProgressResponseReceivedEvent = {
 export type FetchProgressDownloadProgressEvent = {
   readonly type: 'download-progress';
   /**
+   * HTTP status code of the response being downloaded (e.g., 200, 401).
+   *
+   * Progress events fire for 4xx/5xx error bodies too; consumers can
+   * use this to adjust or suppress progress display for error responses.
+   */
+  readonly status: number;
+  /**
    * Number of bytes received so far.
    */
   readonly received: number;
@@ -90,22 +105,36 @@ export type FetchProgressDownloadProgressEvent = {
 };
 
 /**
- * Event fired when download completes successfully.
+ * Event fired when the response body transfer finishes.
  *
- * This event marks the successful completion of the entire request lifecycle,
- * including both preparation and download phases.
+ * `complete` is a fact report: the response body transfer finished.
+ * It makes no claim about HTTP success - mirroring WHATWG `fetch`,
+ * which resolves on 401/404 and rejects only on transport failures,
+ * this event also fires after draining the body of a 4xx/5xx error
+ * response. Check `status` before presenting it as a success.
  *
  * @example
  * ```typescript
  * if (event.type === 'complete') {
- *   console.log(`Downloaded ${event.received} bytes`);
- *   console.log(`Total time: ${event.totalTimeMs}ms`);
- *   console.log(`Download time: ${event.downloadTimeMs}ms`);
+ *   if (event.status >= 200 && event.status < 300) {
+ *     console.log(`Downloaded ${event.received} bytes`);
+ *     console.log(`Total time: ${event.totalTimeMs}ms`);
+ *   } else {
+ *     // e.g., the body was an error payload; let the caller's
+ *     // error handling speak instead of reporting success
+ *   }
  * }
  * ```
  */
 export type FetchProgressCompleteEvent = {
   readonly type: 'complete';
+  /**
+   * HTTP status code of the response (e.g., 200, 401, 404).
+   *
+   * `complete` means the transfer finished, not that the request
+   * succeeded - check this value to distinguish the two.
+   */
+  readonly status: number;
   /**
    * Total number of bytes actually received.
    */
@@ -129,8 +158,12 @@ export type FetchProgressCompleteEvent = {
  * Event fired when an error occurs during stream reading.
  *
  * This event is emitted when an error is thrown while reading the
- * response body stream, such as network errors, timeout errors,
- * or authentication failures (e.g., 401 Unauthorized).
+ * response body stream, such as network errors or timeout errors.
+ *
+ * Note: HTTP error responses (4xx/5xx) do NOT fire this event. Their
+ * body transfer completes normally, so they fire `complete` instead;
+ * check `status` on that event to detect them. This event is reserved
+ * for transport-level failures.
  *
  * @example
  * ```typescript
@@ -143,6 +176,14 @@ export type FetchProgressCompleteEvent = {
  */
 export type FetchProgressErrorEvent = {
   readonly type: 'error';
+  /**
+   * HTTP status code of the response whose body was being read.
+   *
+   * Always available: this event only fires after response headers
+   * have arrived (pre-response failures such as DNS errors reject
+   * the fetch call itself and emit no event).
+   */
+  readonly status: number;
   /**
    * Error message describing what went wrong.
    */
@@ -179,13 +220,18 @@ export type FetchProgressErrorEvent = {
  * 1. `request-start` → Request initiated
  * 2. `response-received` → Headers received
  * 3. `download-progress` (multiple, throttled) → Body streaming
- * 4. `complete` → Download finished successfully
+ * 4. `complete` → Body transfer finished
+ *
+ * **HTTP error flow (4xx/5xx):** same as the success flow. The error
+ * body is still a body, so its transfer ends with `complete`, not
+ * `error`. Check `status` on `response-received` / `complete` to
+ * distinguish this case.
  *
  * **Error flow (stream reading failure):**
  * 1. `request-start` → Request initiated
  * 2. `response-received` → Headers received
  * 3. `download-progress` (optional) → Partial data received
- * 4. `error` → Stream reading failed (e.g., network error, auth failure)
+ * 4. `error` → Stream reading failed (e.g., network error)
  *
  * Note: `download-progress` events may occur before `error` if some chunks
  * were successfully read before the failure.

--- a/lib/fetcher/types/progress-event.types.ts
+++ b/lib/fetcher/types/progress-event.types.ts
@@ -160,10 +160,12 @@ export type FetchProgressCompleteEvent = {
  * This event is emitted when an error is thrown while reading the
  * response body stream, such as network errors or timeout errors.
  *
- * Note: HTTP error responses (4xx/5xx) do NOT fire this event. Their
- * body transfer completes normally, so they fire `complete` instead;
- * check `status` on that event to detect them. This event is reserved
- * for transport-level failures.
+ * Note: a non-2xx HTTP status alone does NOT fire this event. When an
+ * error body (4xx/5xx) is transferred to the end, `complete` fires;
+ * check `status` on that event to detect it. This event fires only
+ * when reading the body stream fails, regardless of the HTTP status -
+ * so `status` here may be any value (e.g., a 200 or 401 response whose
+ * body was cut off mid-transfer).
  *
  * @example
  * ```typescript
@@ -181,7 +183,7 @@ export type FetchProgressErrorEvent = {
    *
    * Always available: this event only fires after response headers
    * have arrived (pre-response failures such as DNS errors reject
-   * the fetch call itself and emit no event).
+   * the fetch call itself and emit no events after `request-start`).
    */
   readonly status: number;
   /**


### PR DESCRIPTION
## Summary

Implements Option 1 of #126: add a required readonly `status` field to all `FetchProgressEvent` variants that fire after response headers arrive (`response-received`, `download-progress`, `complete`, `error`).

Real-time consumers can now distinguish a completed transfer of an error body (e.g. a 97-byte 401 JSON payload) from a successful fetch, instead of reporting "download complete" for error responses.

## Changes

- `lib/fetcher/types/progress-event.types.ts`
  - Add `readonly status: number` to the 4 post-response event types (`request-start` fires before the response exists, so it cannot carry one)
  - Restate the `complete` contract in JSDoc: it is a fact report ("the body transfer finished") and fires for 4xx/5xx as well, mirroring WHATWG `fetch` semantics - check `status` before presenting it as a success
  - Clarify that the `error` event is reserved for transport-level failures during body streaming (4xx/5xx do NOT fire it); `status` is always available there since headers have already arrived
  - Document the HTTP error flow (4xx/5xx) in the lifecycle overview
- `lib/fetcher/client/fetch-with-progress.ts`
  - Pass `status: response.status` at all 5 emission sites (`response` is in scope everywhere, including the ReadableStream callback which closes over the same function scope)
- Tests
  - Add `status` expectations to existing event assertions
  - New test reproducing the observed scenario: a 401 JSON error body without Content-Length fires `response-received` / `download-progress` / `complete` all carrying `status: 401`, and no `error` event

## Compatibility

Additive for normal callback consumers - receiving events is unaffected (verified against PROMIDAS-demo's `progressCallback`, which compiles unchanged). Only code that constructs `FetchProgressEvent` objects itself (e.g. mocks in tests) must now supply `status`. Ships as a minor release with a CHANGELOG note.

## Verification

- `vitest`: 76 files / 1367 tests passed (41 in the touched suite)
- `tsc --noEmit`, `eslint`, `markdownlint` (CHANGELOG.md): clean

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)