### PR TITLE
feat(fetcher): log response envelope at debug level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,15 +26,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
       unaffected. Only code that constructs `FetchProgressEvent` objects
       itself (e.g. mocks in tests) must now supply `status`.
 - **Response envelope logging**: `ProtopediaApiCustomClient` now logs the
-  upstream List Prototypes response envelope (`metadata`, `count`, `links` -
-  everything except `results`) at debug level right after the API call, so
-  the reported `count` can be cross-checked against the number of items
-  actually received. The log payload is `{ envelope, params }` - upstream
-  fields stay nested under `envelope`, separate from the local request
-  `params`, so their origin is unambiguous and future upstream fields
-  cannot collide with local keys. The envelope is a few hundred bytes and
-  is logged even when `results` is absent; `results` itself is excluded
-  because it can be megabytes in size (#127).
+  upstream response envelope (everything except the potentially huge
+  `results`) at debug level as `{ envelope, params }`, so the upstream
+  `count` can be cross-checked against the items actually received - even
+  when `results` is absent (#127).
 
 ## [3.0.1] - 2026-07-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Not breaking for normal callback consumers: receiving events is
       unaffected. Only code that constructs `FetchProgressEvent` objects
       itself (e.g. mocks in tests) must now supply `status`.
+- **Response envelope logging**: `ProtopediaApiCustomClient` now logs the
+  upstream List Prototypes response envelope (`metadata`, `count`, `links` -
+  everything except `results`) at debug level right after the API call, so
+  the reported `count` can be cross-checked against the number of items
+  actually received. The envelope is a few hundred bytes and is logged even
+  when `results` is absent; `results` itself is excluded because it can be
+  megabytes in size (#127).
 
 ## [3.0.1] - 2026-07-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,9 +29,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   upstream List Prototypes response envelope (`metadata`, `count`, `links` -
   everything except `results`) at debug level right after the API call, so
   the reported `count` can be cross-checked against the number of items
-  actually received. The envelope is a few hundred bytes and is logged even
-  when `results` is absent; `results` itself is excluded because it can be
-  megabytes in size (#127).
+  actually received. The log payload is `{ envelope, params }` - upstream
+  fields stay nested under `envelope`, separate from the local request
+  `params`, so their origin is unambiguous and future upstream fields
+  cannot collide with local keys. The envelope is a few hundred bytes and
+  is logged even when `results` is absent; `results` itself is excluded
+  because it can be megabytes in size (#127).
 
 ## [3.0.1] - 2026-07-06
 

--- a/lib/fetcher/__tests__/client/protopedia-api-custom-client/methods/fetch-prototypes.test.ts
+++ b/lib/fetcher/__tests__/client/protopedia-api-custom-client/methods/fetch-prototypes.test.ts
@@ -157,9 +157,11 @@ describe('ProtopediaApiCustomClient - Methods - fetchPrototypes', () => {
       expect(mockLogger.debug).toHaveBeenCalledWith(
         'Upstream API response envelope.',
         {
-          metadata: { detail: 'OK', title: 'OK', status: 200 },
-          count: 1,
-          links: { self: 'https://example.com/api/prototype/list' },
+          envelope: {
+            metadata: { detail: 'OK', title: 'OK', status: 200 },
+            count: 1,
+            links: { self: 'https://example.com/api/prototype/list' },
+          },
           params,
         },
       );
@@ -184,6 +186,8 @@ describe('ProtopediaApiCustomClient - Methods - fetchPrototypes', () => {
       );
       expect(envelopeCall).toBeDefined();
       expect(envelopeCall![1]).not.toHaveProperty('results');
+      expect(envelopeCall![1]).not.toHaveProperty('envelope.results');
+      expect(envelopeCall![1]).toHaveProperty('envelope.count', 2);
     });
 
     it('logs the envelope even when results is absent', async () => {
@@ -203,8 +207,10 @@ describe('ProtopediaApiCustomClient - Methods - fetchPrototypes', () => {
       expect(mockLogger.debug).toHaveBeenCalledWith(
         'Upstream API response envelope.',
         {
-          metadata: { detail: 'OK', title: 'OK', status: 200 },
-          count: 0,
+          envelope: {
+            metadata: { detail: 'OK', title: 'OK', status: 200 },
+            count: 0,
+          },
           params,
         },
       );

--- a/lib/fetcher/__tests__/client/protopedia-api-custom-client/methods/fetch-prototypes.test.ts
+++ b/lib/fetcher/__tests__/client/protopedia-api-custom-client/methods/fetch-prototypes.test.ts
@@ -138,6 +138,79 @@ describe('ProtopediaApiCustomClient - Methods - fetchPrototypes', () => {
     expect(clientInstance.listPrototypes).toHaveBeenCalledTimes(2);
   });
 
+  describe('response envelope logging', () => {
+    it('logs the envelope (non-results fields) at debug level', async () => {
+      const clientInstance = {
+        listPrototypes: vi.fn().mockResolvedValue({
+          metadata: { detail: 'OK', title: 'OK', status: 200 },
+          count: 1,
+          links: { self: 'https://example.com/api/prototype/list' },
+          results: [{ id: 1, prototypeNm: 'p1' }],
+        }),
+      };
+      createProtoPediaClientMock.mockReturnValue(clientInstance);
+
+      const client = new ProtopediaApiCustomClient({ logger: mockLogger });
+      const params = { offset: 0, limit: 10 };
+      await client.fetchPrototypes(params);
+
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        'Upstream API response envelope.',
+        {
+          metadata: { detail: 'OK', title: 'OK', status: 200 },
+          count: 1,
+          links: { self: 'https://example.com/api/prototype/list' },
+          params,
+        },
+      );
+    });
+
+    it('does not include results in the envelope log', async () => {
+      const clientInstance = {
+        listPrototypes: vi.fn().mockResolvedValue({
+          count: 2,
+          results: [{ id: 1 }, { id: 2 }],
+        }),
+      };
+      createProtoPediaClientMock.mockReturnValue(clientInstance);
+
+      const client = new ProtopediaApiCustomClient({ logger: mockLogger });
+      await client.fetchPrototypes({ offset: 0, limit: 10 });
+
+      const envelopeCall = (
+        mockLogger.debug as ReturnType<typeof vi.fn>
+      ).mock.calls.find(
+        (call) => call[0] === 'Upstream API response envelope.',
+      );
+      expect(envelopeCall).toBeDefined();
+      expect(envelopeCall![1]).not.toHaveProperty('results');
+    });
+
+    it('logs the envelope even when results is absent', async () => {
+      const clientInstance = {
+        listPrototypes: vi.fn().mockResolvedValue({
+          metadata: { detail: 'OK', title: 'OK', status: 200 },
+          count: 0,
+        }),
+      };
+      createProtoPediaClientMock.mockReturnValue(clientInstance);
+
+      const client = new ProtopediaApiCustomClient({ logger: mockLogger });
+      const params = { offset: 0, limit: 10 };
+      const result = await client.fetchPrototypes(params);
+
+      expect(result.ok).toBe(true);
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        'Upstream API response envelope.',
+        {
+          metadata: { detail: 'OK', title: 'OK', status: 200 },
+          count: 0,
+          params,
+        },
+      );
+    });
+  });
+
   describe('error handling / logging', () => {
     it('logs with warn for client errors (4xx status)', async () => {
       // Create a plain object that matches ProtoPediaApiError structure

--- a/lib/fetcher/client/protopedia-api-custom-client.ts
+++ b/lib/fetcher/client/protopedia-api-custom-client.ts
@@ -231,18 +231,28 @@ export class ProtopediaApiCustomClient {
     try {
       const upstream = await this.#client.listPrototypes(params);
 
+      // Log the response envelope (everything except `results`) for
+      // diagnostics. The envelope is a few hundred bytes regardless of the
+      // query; `results` is excluded because it can be megabytes in size.
+      // Rest-spread so future envelope fields are logged automatically.
+      const { results, ...envelope } = upstream;
+      this.#logger.debug('Upstream API response envelope.', {
+        ...envelope,
+        params,
+      });
+
       let data: NormalizedPrototype[] = [];
-      if (!Array.isArray(upstream.results)) {
+      if (!Array.isArray(results)) {
         this.#logger.warn(
           'Upstream API response "results" is not an array. Returning empty data.',
           {
-            upstreamResults: upstream.results,
+            upstreamResults: results,
             params,
           },
         );
         // data remains empty array as initialized
       } else {
-        data = upstream.results.map((value, index) => {
+        data = results.map((value, index) => {
           const original = value as UpstreamPrototype;
           const normalized = normalizePrototype(original);
 

--- a/lib/fetcher/client/protopedia-api-custom-client.ts
+++ b/lib/fetcher/client/protopedia-api-custom-client.ts
@@ -235,9 +235,11 @@ export class ProtopediaApiCustomClient {
       // diagnostics. The envelope is a few hundred bytes regardless of the
       // query; `results` is excluded because it can be megabytes in size.
       // Rest-spread so future envelope fields are logged automatically.
+      // Kept under its own key so upstream fields can never collide with
+      // (or be mistaken for) the local `params`.
       const { results, ...envelope } = upstream;
       this.#logger.debug('Upstream API response envelope.', {
-        ...envelope,
+        envelope,
         params,
       });
 


### PR DESCRIPTION
## Summary

Implements #127: `ProtopediaApiCustomClient.#fetchAndNormalizePrototypes` now logs the upstream List Prototypes response envelope (`metadata`, `count`, `links` - everything except `results`) at debug level right after `listPrototypes` returns.

Previously the envelope was discarded immediately, so inconsistencies like "API says count=100 but only 50 items arrived" were invisible even when debugging.

## Changes

- `lib/fetcher/client/protopedia-api-custom-client.ts`
  - Destructure `results` out of the upstream response and `logger.debug` the rest (plus `params`), following the design notes in #127:
    - Rest-spread so future envelope fields are logged automatically
    - Placed before the `Array.isArray(results)` check so the envelope is logged even when `results` is absent (the legitimate `count=0` case)
    - No `sanitizeDataForLogging`: the envelope contains no credentials or personal data
    - Level filtering stays the logger's responsibility
- Tests: 3 new cases - envelope logged with expected fields, `results` excluded from the log payload, envelope logged when `results` is absent
- CHANGELOG entry under Unreleased

Out-of-scope follow-ups listed in #127 (count-based warn suppression, exposing `count` in `FetchPrototypesSuccess`) are intentionally not included.

## Verification

- `vitest`: 76 files / 1370 tests passed
- `tsc --noEmit`, `eslint`, `format:check` (prettier), `markdownlint`: clean

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)